### PR TITLE
Added path prefix for proxy server

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,13 @@ Change the following lines in `config.toml`:
 ldap="ldap.corp.redhat.com"
 address=":8081"
 proxy="http://localhost:8080"
+proxy_prefix="/api/v1/"
 ```
 
  - `ldap` is hostname of LDAP server
  - `address` is address of ldapauth server
  - `proxy` is address of controller server
+ - `proxy_prefix` is prefix of controller server which will be replaced instead of ldapauth prefix
 
 ### Environment variables
 

--- a/config.toml
+++ b/config.toml
@@ -2,3 +2,4 @@
 ldap="ldap.corp.redhat.com"
 address=":8081"
 proxy="http://localhost:8080"
+proxy_prefix="/api/v1/"

--- a/main.go
+++ b/main.go
@@ -43,9 +43,10 @@ func main() {
 
 	serviceCfg := viper.Sub("service")
 	s := server.Server{
-		LDAP:    serviceCfg.GetString("ldap"),
-		Address: serviceCfg.GetString("address"),
-		Proxy:   serviceCfg.GetString("proxy"),
+		LDAP:        serviceCfg.GetString("ldap"),
+		Address:     serviceCfg.GetString("address"),
+		Proxy:       serviceCfg.GetString("proxy"),
+		ProxyPrefix: serviceCfg.GetString("proxy_prefix"),
 	}
 
 	s.Initialize()

--- a/server/proxy.go
+++ b/server/proxy.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 // HandleHTTP handle all routes, used for proxying them to controller
@@ -29,6 +30,7 @@ func (s Server) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 	tempURL, _ := url.Parse(s.Proxy)
 	req.URL.Host = tempURL.Host
 	req.URL.Scheme = tempURL.Scheme
+	req.URL.Path = strings.Replace(req.URL.Path, APIPrefix, s.ProxyPrefix, 1)
 	req.Host = tempURL.Host
 	resp, err := http.DefaultTransport.RoundTrip(req)
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -31,9 +31,10 @@ var APIPrefix = env.GetEnv("CONTROLLER_PREFIX", "/api/v1/")
 
 // Server basic configuration of server
 type Server struct {
-	Address string
-	LDAP    string
-	Proxy   string
+	Address     string
+	LDAP        string
+	Proxy       string
+	ProxyPrefix string
 }
 
 var apiRequests = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -80,6 +81,7 @@ func (s Server) addDefaultHeaders(nextHandler http.Handler) http.Handler {
 
 // Initialize main function that start server
 func (s Server) Initialize() {
+	log.Println("API Prefix: ", APIPrefix)
 	router := mux.NewRouter().StrictSlash(true)
 	router.Use(logRequest)
 	router.Use(s.JWTAuthentication)


### PR DESCRIPTION
# Description

Prefix path for controller and ldapauth could be different, so this change allow to specify prefix for controller.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing steps
This change can be tested by changing in configuration prefix path.