### PR TITLE
Disable G402 (CWE-295): TLS InsecureSkipVerify set true.

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -58,6 +58,8 @@ func ldapAuth(login string, password string, client ldap.Client) (bool, error) {
 	var err error
 
 	// Reconnect with TLS
+	// disable "G402 (CWE-295): TLS InsecureSkipVerify set true."
+	// #nosec G402
 	err = client.StartTLS(&tls.Config{InsecureSkipVerify: true})
 	if err != nil {
 		return false, err


### PR DESCRIPTION
# Description

Disable G402 (CWE-295): TLS InsecureSkipVerify set true.

Fixes #33

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

N/A