### PR TITLE
Refactoring: don't use two string literals that are the same

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -45,6 +45,13 @@ type Account struct {
 	Token    string `json:"token"`
 }
 
+// GetTokenPasswordFromEnv tries to read token password from the environment
+// variable. Content of the variable (string) is converted into array of bytes
+// to be usable.
+func GetTokenPasswordFromEnv() []byte {
+	return []byte(os.Getenv("token_password"))
+}
+
 func createLdapConnection(ldapHost string) (*ldap.Conn, error) {
 	var err error
 	conn, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", ldapHost, 389))
@@ -132,7 +139,7 @@ func Authenticate(login, password, ldap string) (map[string]interface{}, error) 
 	//Create JWT token
 	tk := &Token{Login: account.Login}
 	token := jwt.NewWithClaims(jwt.GetSigningMethod("HS256"), tk)
-	tokenString, _ := token.SignedString([]byte(os.Getenv("token_password")))
+	tokenString, _ := token.SignedString(GetTokenPasswordFromEnv())
 	account.Token = tokenString //Store the token in the response
 
 	resp := responses.BuildResponse("ok")

--- a/server/auth.go
+++ b/server/auth.go
@@ -23,7 +23,6 @@ import (
 	auth "github.com/redhatinsights/insights-operator-ldapauth/auth"
 	"github.com/redhatinsights/insights-operator-utils/responses"
 	"net/http"
-	"os"
 	"strings"
 )
 
@@ -83,7 +82,7 @@ func (s Server) JWTAuthentication(next http.Handler) http.Handler {
 		tk := &auth.Token{}
 
 		token, err := jwt.ParseWithClaims(tokenPart, tk, func(token *jwt.Token) (interface{}, error) {
-			return []byte(os.Getenv("token_password")), nil
+			return auth.GetTokenPasswordFromEnv(), nil
 		})
 
 		if err != nil { //Malformed token, returns with http code 403 as usual


### PR DESCRIPTION
# Description

Refactoring: don't use two string literals that are the same

Fixes #34

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Refactor (refactoring code, removing useless files)

## Testing steps

N/A