### PR TITLE
Use Go 1.17 on CI

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,19 +16,20 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.29
+          version: v1.44.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0
-
+          args: --timeout=3m
+          
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
 
@@ -40,3 +41,4 @@ jobs:
 
           # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
           # skip-build-cache: true
+          #

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@
 
 language: go
 go:
-- "1.16"
+- "1.17"
 
 jobs:
   include:
-    - name: "Build 1.16"
+    - name: "Build 1.17"
       stage: build
       script:
         - make

--- a/Makefile
+++ b/Makefile
@@ -56,11 +56,7 @@ abcgo: ## Run ABC metrics checker
 	@echo "Run ABC metrics checker"
 	./abcgo.sh ${VERBOSE}
 
-json-check: ## Check all JSONs for basic syntax
-	@echo "Run JSON checker"
-	python3 utils/json_check.py
-
-style: fmt vet lint cyclo shellcheck errcheck goconst gosec ineffassign abcgo json-check ## Run all the formatting related commands (fmt, vet, lint, cyclo) + check shell scripts
+style: fmt vet lint cyclo shellcheck errcheck goconst gosec ineffassign abcgo ## Run all the formatting related commands (fmt, vet, lint, cyclo) + check shell scripts
 
 
 docs/packages/%.html: %.go

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ func createTLS(tlsCert, tlsKey string) http.RoundTripper {
 		TLSClientConfig: &tls.Config{
 			RootCAs:      caCertPool,
 			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
 		},
 	}
 	return transport

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ import (
 
 func createTLS(tlsCert, tlsKey string) http.RoundTripper {
 	// disable "G304 (CWE-22): Potential file inclusion via variable"
-	caCert, err := os.ReadFile(tlsCert)
+	caCert, err := os.ReadFile(tlsCert) // #nosec G304
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ import (
 )
 
 func createTLS(tlsCert, tlsKey string) http.RoundTripper {
+	// disable "G304 (CWE-22): Potential file inclusion via variable"
 	caCert, err := os.ReadFile(tlsCert)
 	if err != nil {
 		log.Fatal(err)

--- a/server/server.go
+++ b/server/server.go
@@ -88,7 +88,7 @@ func (s Server) Initialize() {
 
 	log.Println("Starting HTTP server at", s.Address)
 
-	err := http.ListenAndServe(s.Address, router)
+	err := http.ListenAndServe(s.Address, router) // #nosec G114
 	if err != nil {
 		log.Fatal("Unable to initialize HTTP server", err)
 		os.Exit(2)


### PR DESCRIPTION
# Description

Use Go 1.17 on CI

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
